### PR TITLE
Vert.x, Mutiny Bindings and Quarkus updates

### DIFF
--- a/chapter-10/blocking-example/pom.xml
+++ b/chapter-10/blocking-example/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-10/database-example/pom.xml
+++ b/chapter-10/database-example/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>
@@ -67,12 +67,12 @@
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-pg-client</artifactId>
-            <version>2.16.2</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-sql-client</artifactId>
-            <version>2.16.2</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/chapter-10/fault-tolerance-example/pom.xml
+++ b/chapter-10/fault-tolerance-example/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-10/hello-messaging/pom.xml
+++ b/chapter-10/hello-messaging/pom.xml
@@ -15,10 +15,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-10/messages-example/pom.xml
+++ b/chapter-10/messages-example/pom.xml
@@ -15,10 +15,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-10/stream-example/pom.xml
+++ b/chapter-10/stream-example/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-11/processor/pom.xml
+++ b/chapter-11/processor/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-11/ticker/pom.xml
+++ b/chapter-11/ticker/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-11/viewer/pom.xml
+++ b/chapter-11/viewer/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-12/api-gateway-example/api-gateway/pom.xml
+++ b/chapter-12/api-gateway-example/api-gateway/pom.xml
@@ -18,10 +18,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
 

--- a/chapter-12/api-gateway-example/greeting-service/pom.xml
+++ b/chapter-12/api-gateway-example/greeting-service/pom.xml
@@ -17,10 +17,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-12/api-gateway-example/quote-service/pom.xml
+++ b/chapter-12/api-gateway-example/quote-service/pom.xml
@@ -17,10 +17,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-12/http-messaging-example/pom.xml
+++ b/chapter-12/http-messaging-example/pom.xml
@@ -17,10 +17,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-12/rest-client-example/pom.xml
+++ b/chapter-12/rest-client-example/pom.xml
@@ -15,10 +15,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-13/processor-health/pom.xml
+++ b/chapter-13/processor-health/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-13/processor/pom.xml
+++ b/chapter-13/processor/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-13/ticker/pom.xml
+++ b/chapter-13/ticker/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-13/viewer/pom.xml
+++ b/chapter-13/viewer/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-2/code-with-quarkus/pom.xml
+++ b/chapter-2/code-with-quarkus/pom.xml
@@ -15,10 +15,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-2/quarkus-hello/pom.xml
+++ b/chapter-2/quarkus-hello/pom.xml
@@ -15,10 +15,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 

--- a/chapter-3/quarkus-simple-service/pom.xml
+++ b/chapter-3/quarkus-simple-service/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
 

--- a/chapter-5/reactive-programming-examples/pom.xml
+++ b/chapter-5/reactive-programming-examples/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <mutiny.version>1.2.0</mutiny.version>
-        <mutiny-vertx.version>2.16.2</mutiny-vertx.version>
+        <mutiny-vertx.version>2.17.0</mutiny-vertx.version>
     </properties>
 
     <dependencies>

--- a/chapter-7/mutiny-examples/pom.xml
+++ b/chapter-7/mutiny-examples/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <mutiny.version>1.2.0</mutiny.version>
-        <mutiny-vertx.version>2.16.2</mutiny-vertx.version>
+        <mutiny-vertx.version>2.17.0</mutiny-vertx.version>
     </properties>
 
     <dependencies>

--- a/chapter-7/order-example/pom.xml
+++ b/chapter-7/order-example/pom.xml
@@ -14,10 +14,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/chapter-8/mutiny-integration-examples/pom.xml
+++ b/chapter-8/mutiny-integration-examples/pom.xml
@@ -15,10 +15,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/chapter-8/reactive-scores/pom.xml
+++ b/chapter-8/reactive-scores/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/chapter-8/resteasy-reactive-examples/pom.xml
+++ b/chapter-8/resteasy-reactive-examples/pom.xml
@@ -15,10 +15,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/chapter-8/simple-benchmark/classic/pom.xml
+++ b/chapter-8/simple-benchmark/classic/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/chapter-8/simple-benchmark/reactive-blocking/pom.xml
+++ b/chapter-8/simple-benchmark/reactive-blocking/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/chapter-8/simple-benchmark/reactive/pom.xml
+++ b/chapter-8/simple-benchmark/reactive/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/chapter-9/debezium/pom.xml
+++ b/chapter-9/debezium/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-9/hibernate-reactive/pom.xml
+++ b/chapter-9/hibernate-reactive/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/chapter-9/redis/pom.xml
+++ b/chapter-9/redis/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
 
         <docker-plugin.version>0.38.1</docker-plugin.version>


### PR DESCRIPTION
- Bump smallrye-mutiny-vertx-sql-client from 2.16.2 to 2.17.0
- Bump smallrye-mutiny-vertx-core from 2.16.2 to 2.17.0
- Bump quarkus-bom from 2.4.2.Final to 2.6.1.Final
- Bump quarkus-maven-plugin from 2.4.2.Final to 2.6.1.Final